### PR TITLE
Fix C++ Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pymobiledevice3>=3.4.0,<3.5.0
+pymobiledevice3>=4.2.3
 Flask==3.0.2
 zeroconf==0.132.2


### PR DESCRIPTION
This Pull request changes the requirements to update Pymd3 to the latest version and allowing for the C++ compiler error to be removed as of Pymd3 update [4.2.1](https://github.com/doronz88/pymobiledevice3/releases/tag/v4.2.1)

 it will help with the unable to connect to device error as version [4.2.2](https://github.com/doronz88/pymobiledevice3/releases/tag/v4.2.2) of pymd3 added more IP address support.
 
 This has been fully tested by me (stossy11) and @gamerbest480 on the SideStore Discord