### PR TITLE
Compile to direct executable on Windows x64, Ubuntu x64, and MacOS arm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,11 @@
 **/values.dev.yaml
 LICENSE
 README.md
+
+# nuitka
+*.bin
+*.exe
+*.build
+*.dist
+*.onefile_dist
+*compilation-report.xml

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,75 @@
+name: Compile Executables
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  release:
+    types: [ created ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false # needed to keep running other os builds even if one fails
+
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with: # needed for tag info for nightly sdist builds
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11' # nuitka 2.2 and lower does not support 3.12 yet
+          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+
+      # Install dependencies
+      - name: Install Dependencies and Build sdist
+        run: |
+          pip install -r requirements.txt
+          pip install -U build setuptools
+          python -m build # create the sdist build to populate the __version__ var
+
+      # Build python script into a standalone exe
+      - name: Build Executable
+        uses: Nuitka/Nuitka-Action@main
+        with:
+          nuitka-version: main
+          script-name: SideJITServer/launch.py
+
+      - name: Upload Compilation Report
+        if: always() # run even if the compile failed
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ runner.os }} compilation report
+          path: compilation-report.xml
+
+      - name: Upload Executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ runner.os }} Build
+          path: |
+            build/*.exe
+            build/*.bin
+            build/*.app/**/*
+
+      - name: Check if executable runs (.exe)
+        if: ${{ runner.os == 'Windows' }}
+        run: ./build/*.exe --version
+
+      - name: Check if executable runs (.bin)
+        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
+        run: ./build/*.bin --version

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11' # nuitka 2.2 and lower does not support 3.12 yet
+          python-version: '3.11' # nuitka 2.2 does not support 3.12
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
           cache: 'pip'
           cache-dependency-path: |
@@ -47,7 +47,7 @@ jobs:
       - name: Build Executable
         uses: Nuitka/Nuitka-Action@main
         with:
-          nuitka-version: main
+          nuitka-version: 2.2.3 # 2.3 does not work on mac for some reason
           script-name: SideJITServer/launch.py
 
       - name: Upload Compilation Report

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,11 @@ cython_debug/
 
 # macOS
 .DS_Store
+
+# nuitka
+*.bin
+*.exe
+*.build
+*.dist
+*.onefile_dist
+*compilation-report.xml

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -1,0 +1,13 @@
+# Compilation notes for standalone no-python executable
+
+Compilation happens using a package called nuitka, which transpiles everything to C and then uses the appropriate C compiler to build an executable. It is handled in three files in this repo:
+
+1. `./sidejitserver-nuitka-package.config.yml` for platform-specific (Windows) dylib linking
+2. `./SideJITServer/launch.py` which is a duplicate of `main.py`, but using a package import and including necessary nuitka compilation flags including critical hidden imports
+3. `./.github/workflows/compile.yml` which lists compilation instructions on release or manual trigger.
+
+Compilation lasts between 25-50 minutes depending on platform from an empty cache, on the free tier GitHub Actions runners. Recompilation with an existing cache usually takes 7-15 minutes.
+
+When making a release, wait for the compilation to finish, and then download + attach the executables to the release after the jobs are finished.
+
+If you want to compile it yourself on your own machine, study the launch.py file and the github workflow to understand how to do it, and change any configs as necessary to fit your machine architecture.

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -11,3 +11,5 @@ Compilation lasts between 25-50 minutes depending on platform from an empty cach
 When making a release, wait for the compilation to finish, and then download + attach the executables to the release after the jobs are finished.
 
 If you want to compile it yourself on your own machine, study the launch.py file and the github workflow to understand how to do it, and change any configs as necessary to fit your machine architecture.
+
+Note: currently pinned to python 3.11 and nuitka 2.2.3 since nuitka 2.3 does not work on Mac.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 This project allows you to start a server that wirelessly or via USB gives you JIT for iOS 17+ on Windows/macOS/Linux if you use the correct newer pymobiledevice3 version.
 
 ## How to get this running (Run with Administrator!)
+
+### Option 1: Python install
 ```
 python3 -m venv venv # Run inside SideJITStore directory!
 
@@ -35,9 +37,18 @@ python3 -m venv venv
 pip3 install SideJITServer
 SideJITServer --help
 ```
+
+### Option 2: Direct download (if available)
+Go to the latest [GitHub Release](https://github.com/nythepegasus/SideJITServer/releases/latest) and check if there are executable downloads, such as `SideJITServer-windows-x86_64.exe`, depending on your OS and your architecture.
+
+Download the correct executable, and run it as Administrator from your terminal or Powershell following the directions below. If you are on Mac or Linux, you must first run `chmod +x ./(your downloaded .bin file)` before executing the file with sudo.
+
+Python is not necessary for this approach.
+
+
 # How to use SideJITServer?
 - Make sure your device is connected!
-- Make sure you're still inside the venv!
+- Make sure you're still inside the venv, if applicable!
 - Common Knowledge
   
 Now run `SideJITServer --pair` and on your PC make sure you click on Trust this PC!

--- a/SideJITServer/launch.py
+++ b/SideJITServer/launch.py
@@ -1,0 +1,31 @@
+# configuration and launch file for nuitka compilation
+
+# Make executable standalone
+# nuitka-project-if: {OS} in ("Windows", "Linux", "Darwin", "FreeBSD"):
+#    nuitka-project: --onefile
+#    nuitka-project: --onefile-tempdir-spec="{CACHE_DIR}/SideJITServer"
+# nuitka-project-else:
+#    nuitka-project: --standalone
+
+# nuitka-project-if: {OS} == "Windows":
+#    nuitka-project: --output-filename=SideJITServer-windows-x86_64.exe
+#    nuitka-project: --include-module=jinxed.terminfo.vtwin10
+#    nuitka-project: --include-module=jinxed.terminfo.ansicon
+#    nuitka-project: --include-module=jinxed.terminfo.xterm
+#    nuitka-project: --include-module=jinxed.terminfo.xterm_256color
+#    nuitka-project: --user-package-configuration-file=sidejitserver-nuitka-package.config.yml
+# nuitka-project-if: {OS} == "Linux":
+#    nuitka-project: --output-filename=SideJITServer-linux-x86_64.bin
+# nuitka-project-if: {OS} == "Darwin":
+#    nuitka-project: --output-filename=SideJITServer-mac-arm64.bin
+
+# nuitka-project: --include-module=zeroconf._utils.ipaddress
+# nuitka-project: --include-module=zeroconf._handlers.answers
+# nuitka-project: --include-module=pkg_resources.extern
+
+# nuitka-project: --report=compilation-report.xml
+
+from SideJITServer import start_server
+
+if __name__ == '__main__':
+    start_server()

--- a/sidejitserver-nuitka-package.config.yml
+++ b/sidejitserver-nuitka-package.config.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+# yamllint disable rule:indentation
+# yamllint disable rule:comments-indentation
+# too many spelling things, spell-checker: disable
+---
+
+- module-name: 'pytun_pmd3'
+  dlls:
+    - from_filenames:
+        relative_path: 'wintun/bin/x86'
+        prefixes:
+          - 'wintun'
+      when: 'win32 and arch_x86'
+    - from_filenames:
+        relative_path: 'wintun/bin/amd64'
+        prefixes:
+          - 'wintun'
+      when: 'win32 and arch_amd64'


### PR DESCRIPTION
Adds compilation with Nuitka, which removes any need for installation. The user can directly download the file and execute it without having Python at all.

Wrote sparse additional documentation. If additional documentation is necessary, I can add more. For example, I can imagine people being confused by antivirus things, etc. because the direct executable versions are a little weird the first time they are run.