### PR TITLE
Compatibility with iOS 18.2 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SideJITServer
-This project allows you to start a server that wirelessly or via USB gives you JIT for iOS 17+ on Windows/macOS/Linux if you use the correct newer pymobiledevice3 version.
+This project allows you to start a server that wirelessly or via USB gives you JIT for iOS 17+ on Windows/macOS/Linux if you use the correct newer pymobiledevice3 version. Due to changes in iOS 18.2 this project now requires Python 3.13 or above.
 
 ## How to get this running (Run with Administrator!)
 

--- a/SideJITServer/__init__.py
+++ b/SideJITServer/__init__.py
@@ -184,7 +184,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             
 def start_tunneld_proc():
     TunneldRunner.create(TUNNELD_DEFAULT_ADDRESS[0], TUNNELD_DEFAULT_ADDRESS[1],
-                         protocol=TunnelProtocol('quic'), mobdev2_monitor=True, usb_monitor=True, wifi_monitor=True, usbmux_monitor=True)
+                         protocol=TunnelProtocol('tcp'), mobdev2_monitor=True, usb_monitor=True, wifi_monitor=True, usbmux_monitor=True)
 
 def prompt_device_list(device_list: list):
     device_question = [inquirer3.List('device', message='choose device', choices=device_list, carousel=True)]

--- a/SideJITServer/__init__.py
+++ b/SideJITServer/__init__.py
@@ -183,8 +183,12 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         self._send_json_response(status_code, response)
             
 def start_tunneld_proc():
-    TunneldRunner.create(TUNNELD_DEFAULT_ADDRESS[0], TUNNELD_DEFAULT_ADDRESS[1],
-                         protocol=TunnelProtocol('tcp'), mobdev2_monitor=True, usb_monitor=True, wifi_monitor=True, usbmux_monitor=True)
+    if sys.version_info >= (3, 13):
+        TunneldRunner.create(TUNNELD_DEFAULT_ADDRESS[0], TUNNELD_DEFAULT_ADDRESS[1],
+                              protocol=TunnelProtocol('tcp'), mobdev2_monitor=True, usb_monitor=True, wifi_monitor=True, usbmux_monitor=True)
+    else:
+        TunneldRunner.create(TUNNELD_DEFAULT_ADDRESS[0], TUNNELD_DEFAULT_ADDRESS[1],
+                              protocol=TunnelProtocol('quic'), mobdev2_monitor=True, usb_monitor=True, wifi_monitor=True, usbmux_monitor=True)
 
 def prompt_device_list(device_list: list):
     device_question = [inquirer3.List('device', message='choose device', choices=device_list, carousel=True)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
 ]
 description = "SideJITServer is an iOS 17 JIT enabler for Windows/macOS!"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.13"
 keywords = ["ios", "automation", "cli", "jit"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
iOS 18.2 introduced changes requiring TCP, as QUIC is no longer supported. However, TCP support comes with the requirement of Python 3.13 or later. This pull request aims to address these changes but requires further testing to ensure functionality.